### PR TITLE
Fix Metal shader compile issue

### DIFF
--- a/src/shaders/clouds_compute.wgsl
+++ b/src/shaders/clouds_compute.wgsl
@@ -370,7 +370,13 @@ fn update(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_
     let index = vec2f(f32(invocation_id.x), f32(invocation_id.y)) + vec2f(0.5);
 
     // Load old camera matrix before storageBarrier to prevent race conditions;
-    let old_cam = common::load_camera(clouds_render_texture, u32(config.render_resolution.y) - 1);
+    let sample_y = u32(config.render_resolution.y) - 1;
+    let old_cam = mat4x4f(
+        textureLoad(clouds_render_texture, vec2u(1, sample_y)),
+        textureLoad(clouds_render_texture, vec2u(2, sample_y)),
+        textureLoad(clouds_render_texture, vec2u(3, sample_y)),
+        textureLoad(clouds_render_texture, vec2u(4, sample_y)),
+    );
     var frag_coord = vec2f(index.x, config.render_resolution.y - index.y);
 
     var ray_origin = get_ray_origin(config.time);

--- a/src/shaders/common.wgsl
+++ b/src/shaders/common.wgsl
@@ -27,15 +27,6 @@ fn save_camera(camera: mat4x4f, frag_coord: vec2f, ray_origin: vec3f) -> vec4f {
     return vec4f(0.0);
 }
 
-fn load_camera(texture: texture_storage_2d<rgba32float, read_write>, sample_y: u32) -> mat4x4f {
-    return mat4x4f(
-        textureLoad(texture, vec2u(1, sample_y)),
-        textureLoad(texture, vec2u(2, sample_y)),
-        textureLoad(texture, vec2u(3, sample_y)),
-        textureLoad(texture, vec2u(4, sample_y)),
-    );
-}
-
 // Noise functions
 //
 // Hash without Sine by Dave Hoskins


### PR DESCRIPTION
Passing a read_write storage texture (like `clouds_render_texture`) as an arg to a helper function can cause permission confusions in Metal.  By moving into main function, compiler can easily see that the global variable has read_write permissions.

To remain in scope we must change from `texture` to `clouds_render_texture`.

Tested on: Metal, Windows Vulkan