### PR TITLE
Resolve camera synchronization jitter

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ impl Plugin for CloudsPlugin {
             .add_systems(
                 PostUpdate,
                 (update_skybox_transform, update_camera_matrices)
-                    .after(bevy::transform::TransformSystems::Propagate),
+                    .after(TransformSystems::Propagate),
             );
         #[cfg(feature = "debug")]
         app.add_systems(EguiPrimaryContextPass, ui_system);


### PR DESCRIPTION
The volumetric clouds plugin was running `update_skybox_transform` & `update_camera_matrices` in Update which was causing the clouds to jitter when moving cameras that run in PostUpdate.  I patched to make these systems run in PostUpdate explicitly after TransformSystems::Propagate.

You can trim the 'bevy::transform' from 'bevy::transform::TransformSystems::Propagate' if it throws a warning.  I noticed that when running an example from your repo but not when running my game, weirdly.

Tested on: OSX 15.6 Metal