### PR TITLE
Add a component to specify which camera has clouds

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ use bevy_volumetric_clouds::CloudsPlugin;
 app.add_plugins(CloudsPlugin);
 ```
 
+Then add `CloudCamera` component to the camera that should have clouds.
+```rust
+commands.spawn((Camera3d::default(), Hdr, CloudCamera));
+```
+
 Look at [the minimal example](examples/minimal.rs) for a working example.
 
 The [the demo example](examples/demo.rs) features a usable demo where you can move the camera around

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -6,9 +6,9 @@ use bevy::prelude::*;
 use bevy::render::view::Hdr;
 #[cfg(feature = "debug")]
 use bevy_egui::EguiPlugin;
-use bevy_volumetric_clouds::CloudsPlugin;
 #[cfg(feature = "fly_camera")]
 use bevy_volumetric_clouds::fly_camera::{FlyCam, FlyCameraPlugin};
+use bevy_volumetric_clouds::{CloudCamera, CloudsPlugin};
 
 fn close_on_esc(
     mut commands: Commands,
@@ -45,6 +45,7 @@ fn setup(
     commands.spawn((
         Camera3d::default(),
         Hdr,
+        CloudCamera,
         #[cfg(feature = "fly_camera")]
         FlyCam,
         Transform::from_translation(Vec3::new(0.0, 3.0, 0.0)).looking_to(Vec3::X, Vec3::Y),

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,6 +1,6 @@
 //! A minimal example featuring clouds.
 use bevy::{prelude::*, render::view::Hdr};
-use bevy_volumetric_clouds::CloudsPlugin;
+use bevy_volumetric_clouds::{CloudCamera, CloudsPlugin};
 
 fn main() {
     App::new()
@@ -10,5 +10,5 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    commands.spawn((Camera3d::default(), Hdr));
+    commands.spawn((Camera3d::default(), Hdr, CloudCamera));
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -57,10 +57,7 @@ fn prepare_uniforms_bind_group(
     render_device: Res<RenderDevice>,
     time: Res<Time>,
 ) {
-    let Some(camera) = camera else {
-        warn_once!("No camera with CloudCamera component found. Clouds will not render.");
-        return;
-    };
+    let camera = camera.expect("No camera with CloudCamera component found.");
     let buffer = clouds_uniform_buffer.buffer.get_mut();
 
     buffer.clouds_raymarch_steps_count = clouds_config.clouds_raymarch_steps_count;

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -312,7 +312,6 @@ fn extract_camera_matrices(
     mut commands: Commands,
     camera: Extract<Single<(&GlobalTransform, &Projection), With<CloudCamera>>>,
 ) {
-    let view: Mat4 = camera.0.affine().inverse().into();
     let proj: Mat4 = match camera.1 {
         Projection::Perspective(p) => p.get_clip_from_view(),
         Projection::Orthographic(o) => o.get_clip_from_view(),
@@ -320,7 +319,7 @@ fn extract_camera_matrices(
     };
     commands.insert_resource(CameraMatrices {
         translation: camera.0.translation(),
-        inverse_camera_view: view,
+        inverse_camera_view: camera.0.to_matrix(),
         inverse_camera_projection: proj.inverse(),
     });
 }

--- a/src/compute.rs
+++ b/src/compute.rs
@@ -1,12 +1,17 @@
 use bevy::{
     asset::load_embedded_asset,
+    camera::CameraProjection,
+    core_pipeline::core_3d::graph::{Core3d, Node3d},
     ecs::system::ResMut,
     prelude::*,
     render::{
         Extract, Render, RenderApp, RenderSystems,
+        extract_component::ExtractComponentPlugin,
         extract_resource::ExtractResourcePlugin,
         render_asset::RenderAssets,
-        render_graph::{Node, NodeRunError, RenderGraph, RenderGraphContext, RenderLabel},
+        render_graph::{
+            NodeRunError, RenderGraphContext, RenderGraphExt, RenderLabel, ViewNode, ViewNodeRunner,
+        },
         render_resource::{
             AsBindGroup, BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries,
             CachedComputePipelineId, CachedPipelineState, ComputePassDescriptor,
@@ -19,7 +24,7 @@ use bevy::{
 /// Controls the compute shader which renders the volumetric clouds.
 use std::borrow::Cow;
 
-use crate::config::CloudsConfig;
+use crate::{CloudCamera, config::CloudsConfig};
 
 use super::{
     images::IMAGE_SIZE,
@@ -47,11 +52,15 @@ fn prepare_uniforms_bind_group(
     pipeline: Res<CloudsPipeline>,
     render_queue: Res<RenderQueue>,
     mut clouds_uniform_buffer: ResMut<CloudsUniformBuffer>,
-    camera: ResMut<CameraMatrices>,
+    camera: Option<Res<CameraMatrices>>,
     clouds_config: Res<CloudsConfig>,
     render_device: Res<RenderDevice>,
     time: Res<Time>,
 ) {
+    let Some(camera) = camera else {
+        warn_once!("No camera with CloudCamera component found. Clouds will not render.");
+        return;
+    };
     let buffer = clouds_uniform_buffer.buffer.get_mut();
 
     buffer.clouds_raymarch_steps_count = clouds_config.clouds_raymarch_steps_count;
@@ -200,27 +209,25 @@ impl Default for CloudsNode {
     }
 }
 
-impl Node for CloudsNode {
+impl ViewNode for CloudsNode {
+    type ViewQuery = Has<CloudCamera>;
+
     fn update(&mut self, world: &mut World) {
         let pipeline = world.resource::<CloudsPipeline>();
-        let pipeline_cache = world.resource::<PipelineCache>();
+        let cache = world.resource::<PipelineCache>();
 
         // if the corresponding pipeline has loaded, transition to the next stage
         match self.state {
             CloudsState::Loading => {
-                if let CachedPipelineState::Ok(_) =
-                    pipeline_cache.get_compute_pipeline_state(pipeline.init_pipeline)
-                {
-                    self.state = CloudsState::Init;
+                match cache.get_compute_pipeline_state(pipeline.init_pipeline) {
+                    CachedPipelineState::Ok(_) => self.state = CloudsState::Init,
+                    _ => {}
                 }
             }
-            CloudsState::Init => {
-                if let CachedPipelineState::Ok(_) =
-                    pipeline_cache.get_compute_pipeline_state(pipeline.update_pipeline)
-                {
-                    self.state = CloudsState::Update;
-                }
-            }
+            CloudsState::Init => match cache.get_compute_pipeline_state(pipeline.update_pipeline) {
+                CachedPipelineState::Ok(_) => self.state = CloudsState::Update,
+                _ => {}
+            },
             CloudsState::Update => {}
         }
     }
@@ -229,8 +236,12 @@ impl Node for CloudsNode {
         &self,
         _graph: &mut RenderGraphContext,
         render_context: &mut RenderContext,
+        is_cloud_camera: bool,
         world: &World,
     ) -> Result<(), NodeRunError> {
+        if !is_cloud_camera {
+            return Ok(());
+        }
         let texture_bind_group = &world.resource::<CloudsImageBindGroup>().0;
         let uniform_bind_group = &world.resource::<CloudsUniformBindGroup>().0;
         let pipeline_cache = world.resource::<PipelineCache>();
@@ -242,32 +253,14 @@ impl Node for CloudsNode {
 
         pass.set_bind_group(0, uniform_bind_group, &[]);
         pass.set_bind_group(1, texture_bind_group, &[]);
-
-        match self.state {
-            CloudsState::Loading => {}
-            CloudsState::Init => {
-                let init_pipeline = pipeline_cache
-                    .get_compute_pipeline(pipeline.init_pipeline)
-                    .unwrap();
-                pass.set_pipeline(init_pipeline);
-                pass.dispatch_workgroups(
-                    IMAGE_SIZE / WORKGROUP_SIZE,
-                    IMAGE_SIZE / WORKGROUP_SIZE,
-                    1,
-                );
-            }
-            CloudsState::Update => {
-                let update_pipeline = pipeline_cache
-                    .get_compute_pipeline(pipeline.update_pipeline)
-                    .unwrap();
-                pass.set_pipeline(update_pipeline);
-                pass.dispatch_workgroups(
-                    IMAGE_SIZE / WORKGROUP_SIZE,
-                    IMAGE_SIZE / WORKGROUP_SIZE,
-                    1,
-                );
-            }
-        }
+        let compute = match self.state {
+            CloudsState::Init => pipeline.init_pipeline,
+            CloudsState::Update => pipeline.update_pipeline,
+            _ => return Ok(()),
+        };
+        let pipeline = pipeline_cache.get_compute_pipeline(compute).unwrap();
+        pass.set_pipeline(pipeline);
+        pass.dispatch_workgroups(IMAGE_SIZE / WORKGROUP_SIZE, IMAGE_SIZE / WORKGROUP_SIZE, 1);
         Ok(())
     }
 }
@@ -282,7 +275,7 @@ impl Plugin for CloudsComputePlugin {
     fn build(&self, app: &mut App) {
         app.add_plugins(ExtractResourcePlugin::<CloudsImage>::default());
         app.add_plugins(ExtractResourcePlugin::<CloudsUniform>::default());
-
+        app.add_plugins(ExtractComponentPlugin::<CloudCamera>::default());
         let render_app = app.sub_app_mut(RenderApp);
         render_app.add_systems(
             Render,
@@ -292,11 +285,8 @@ impl Plugin for CloudsComputePlugin {
             Render,
             prepare_uniforms_bind_group.in_set(RenderSystems::PrepareResources),
         );
-
-        let mut render_graph = render_app.world_mut().resource_mut::<RenderGraph>();
-        render_graph.add_node(CloudsLabel, CloudsNode::default());
-        render_graph.add_node_edge(CloudsLabel, bevy::render::graph::CameraDriverLabel);
-
+        render_app.add_render_graph_node::<ViewNodeRunner<CloudsNode>>(Core3d, CloudsLabel);
+        render_app.add_render_graph_edge(Core3d, Node3d::EndMainPass, CloudsLabel);
         render_app.add_systems(
             ExtractSchedule,
             (extract_clouds_config, extract_time, extract_camera_matrices),
@@ -318,6 +308,19 @@ fn extract_time(mut commands: Commands, time: Extract<Res<Time>>) {
     commands.insert_resource(**time);
 }
 
-fn extract_camera_matrices(mut commands: Commands, camera: Extract<Res<CameraMatrices>>) {
-    commands.insert_resource(**camera);
+fn extract_camera_matrices(
+    mut commands: Commands,
+    camera: Extract<Single<(&GlobalTransform, &Projection), With<CloudCamera>>>,
+) {
+    let view: Mat4 = camera.0.affine().inverse().into();
+    let proj: Mat4 = match camera.1 {
+        Projection::Perspective(p) => p.get_clip_from_view(),
+        Projection::Orthographic(o) => o.get_clip_from_view(),
+        Projection::Custom(c) => c.get_clip_from_view(),
+    };
+    commands.insert_resource(CameraMatrices {
+        translation: camera.0.translation(),
+        inverse_camera_view: view,
+        inverse_camera_projection: proj.inverse(),
+    });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,10 @@ use crate::{
 
 use self::compute::CloudsComputePlugin;
 
+/// Marker component to skip volumetric clouds rendering for a specific camera
+#[derive(Component)]
+pub struct SkipVolumetricClouds;
+
 /// A plugin for rendering clouds.
 ///
 /// The configuration of the clouds can be changed using the [`CloudsConfig`] resource.
@@ -84,7 +88,7 @@ fn clouds_setup(
 }
 
 fn update_camera_matrices(
-    cam_query: Single<(&GlobalTransform, &Camera)>,
+    cam_query: Single<(&GlobalTransform, &Camera), Without<SkipVolumetricClouds>>,
     mut config: ResMut<CameraMatrices>,
 ) {
     let (camera_transform, camera) = *cam_query;

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -7,6 +7,7 @@ use crate::CloudCamera;
 #[derive(Component)]
 pub(crate) struct SkyboxPlane {
     pub orig_translation: Vec3,
+    pub orig_rotation: Quat,
 }
 
 pub(crate) struct SkyboxMaterials<M: Material> {
@@ -44,13 +45,14 @@ pub(crate) fn init_skybox_mesh<M: Material>(
     let mesh = meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(box_size)));
 
     // negative x
+    let rotation_nx = Quat::from_rotation_z(-PI * 0.5) * Quat::from_rotation_y(PI * 0.5);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.nx,
-        Transform::from_translation(Vec3::new(-box_size, 0.0, 0.0))
-            .with_rotation(Quat::from_rotation_z(-PI * 0.5) * Quat::from_rotation_y(PI * 0.5)),
+        Transform::from_translation(Vec3::new(-box_size, 0.0, 0.0)).with_rotation(rotation_nx),
         SkyboxPlane {
             orig_translation: Vec3::new(-box_size, 0.0, 0.0),
+            orig_rotation: rotation_nx,
         },
     ));
 
@@ -61,50 +63,55 @@ pub(crate) fn init_skybox_mesh<M: Material>(
         Transform::from_translation(Vec3::new(0.0, -box_size, 0.0)),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, -box_size, 0.0),
+            orig_rotation: Quat::IDENTITY,
         },
     ));
 
     // negative z
+    let rotation_nz = Quat::from_rotation_x(PI * 0.5);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.nz,
-        Transform::from_translation(Vec3::new(0.0, 0.0, -box_size))
-            .with_rotation(Quat::from_rotation_x(PI * 0.5)),
+        Transform::from_translation(Vec3::new(0.0, 0.0, -box_size)).with_rotation(rotation_nz),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, 0.0, -box_size),
+            orig_rotation: rotation_nz,
         },
     ));
 
     // positive x
+    let rotation_px = Quat::from_rotation_z(PI * 0.5) * Quat::from_rotation_y(-PI * 0.5);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.px,
-        Transform::from_translation(Vec3::new(box_size, 0.0, 0.0))
-            .with_rotation(Quat::from_rotation_z(PI * 0.5) * Quat::from_rotation_y(-PI * 0.5)),
+        Transform::from_translation(Vec3::new(box_size, 0.0, 0.0)).with_rotation(rotation_px),
         SkyboxPlane {
             orig_translation: Vec3::new(box_size, 0.0, 0.0),
+            orig_rotation: rotation_px,
         },
     ));
 
     // positive y
+    let rotation_py = Quat::from_rotation_z(PI) * Quat::from_rotation_y(PI);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.py,
-        Transform::from_translation(Vec3::new(0.0, box_size, 0.0))
-            .with_rotation(Quat::from_rotation_z(PI) * Quat::from_rotation_y(PI)),
+        Transform::from_translation(Vec3::new(0.0, box_size, 0.0)).with_rotation(rotation_py),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, box_size, 0.0),
+            orig_rotation: rotation_py,
         },
     ));
 
     // positive z
+    let rotation_pz = Quat::from_rotation_x(-PI * 0.5) * Quat::from_rotation_y(PI);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.pz,
-        Transform::from_translation(Vec3::new(0.0, 0.0, box_size))
-            .with_rotation(Quat::from_rotation_x(-PI * 0.5) * Quat::from_rotation_y(PI)),
+        Transform::from_translation(Vec3::new(0.0, 0.0, box_size)).with_rotation(rotation_pz),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, 0.0, box_size),
+            orig_rotation: rotation_pz,
         },
     ));
 }
@@ -121,7 +128,7 @@ pub(crate) fn setup_daylight(mut commands: Commands) {
 
 pub(crate) fn update_skybox_transform(
     camera: Single<
-        (&Transform, &Camera, &Projection),
+        (&GlobalTransform, &Camera, &Projection),
         (Without<SkyboxPlane>, With<CloudCamera>),
     >,
     mut skybox: Query<(&mut Transform, &SkyboxPlane)>,
@@ -136,6 +143,7 @@ pub(crate) fn update_skybox_transform(
 
     for (mut transform, plane) in skybox.iter_mut() {
         transform.scale = Vec3::splat(scale);
-        transform.translation = camera.0.translation + plane.orig_translation * scale;
+        transform.translation = camera.0.translation() + plane.orig_translation * scale;
+        transform.rotation = plane.orig_rotation;
     }
 }

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -2,6 +2,8 @@ use core::f32::consts::PI;
 
 use bevy::{light::light_consts::lux::FULL_DAYLIGHT, prelude::*};
 
+use crate::CloudCamera;
+
 #[derive(Component)]
 pub(crate) struct SkyboxPlane {
     pub orig_translation: Vec3,
@@ -118,7 +120,10 @@ pub(crate) fn setup_daylight(mut commands: Commands) {
 }
 
 pub(crate) fn update_skybox_transform(
-    camera: Single<(&Transform, &Camera, &Projection), Without<SkyboxPlane>>,
+    camera: Single<
+        (&Transform, &Camera, &Projection),
+        (Without<SkyboxPlane>, With<CloudCamera>),
+    >,
     mut skybox: Query<(&mut Transform, &SkyboxPlane)>,
 ) {
     let far = match camera.2 {

--- a/src/skybox.rs
+++ b/src/skybox.rs
@@ -7,7 +7,6 @@ use crate::CloudCamera;
 #[derive(Component)]
 pub(crate) struct SkyboxPlane {
     pub orig_translation: Vec3,
-    pub orig_rotation: Quat,
 }
 
 pub(crate) struct SkyboxMaterials<M: Material> {
@@ -45,14 +44,13 @@ pub(crate) fn init_skybox_mesh<M: Material>(
     let mesh = meshes.add(Plane3d::new(Vec3::Y, Vec2::splat(box_size)));
 
     // negative x
-    let rotation_nx = Quat::from_rotation_z(-PI * 0.5) * Quat::from_rotation_y(PI * 0.5);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.nx,
-        Transform::from_translation(Vec3::new(-box_size, 0.0, 0.0)).with_rotation(rotation_nx),
+        Transform::from_translation(Vec3::new(-box_size, 0.0, 0.0))
+            .with_rotation(Quat::from_rotation_z(-PI * 0.5) * Quat::from_rotation_y(PI * 0.5)),
         SkyboxPlane {
             orig_translation: Vec3::new(-box_size, 0.0, 0.0),
-            orig_rotation: rotation_nx,
         },
     ));
 
@@ -63,55 +61,50 @@ pub(crate) fn init_skybox_mesh<M: Material>(
         Transform::from_translation(Vec3::new(0.0, -box_size, 0.0)),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, -box_size, 0.0),
-            orig_rotation: Quat::IDENTITY,
         },
     ));
 
     // negative z
-    let rotation_nz = Quat::from_rotation_x(PI * 0.5);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.nz,
-        Transform::from_translation(Vec3::new(0.0, 0.0, -box_size)).with_rotation(rotation_nz),
+        Transform::from_translation(Vec3::new(0.0, 0.0, -box_size))
+            .with_rotation(Quat::from_rotation_x(PI * 0.5)),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, 0.0, -box_size),
-            orig_rotation: rotation_nz,
         },
     ));
 
     // positive x
-    let rotation_px = Quat::from_rotation_z(PI * 0.5) * Quat::from_rotation_y(-PI * 0.5);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.px,
-        Transform::from_translation(Vec3::new(box_size, 0.0, 0.0)).with_rotation(rotation_px),
+        Transform::from_translation(Vec3::new(box_size, 0.0, 0.0))
+            .with_rotation(Quat::from_rotation_z(PI * 0.5) * Quat::from_rotation_y(-PI * 0.5)),
         SkyboxPlane {
             orig_translation: Vec3::new(box_size, 0.0, 0.0),
-            orig_rotation: rotation_px,
         },
     ));
 
     // positive y
-    let rotation_py = Quat::from_rotation_z(PI) * Quat::from_rotation_y(PI);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.py,
-        Transform::from_translation(Vec3::new(0.0, box_size, 0.0)).with_rotation(rotation_py),
+        Transform::from_translation(Vec3::new(0.0, box_size, 0.0))
+            .with_rotation(Quat::from_rotation_z(PI) * Quat::from_rotation_y(PI)),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, box_size, 0.0),
-            orig_rotation: rotation_py,
         },
     ));
 
     // positive z
-    let rotation_pz = Quat::from_rotation_x(-PI * 0.5) * Quat::from_rotation_y(PI);
     commands.spawn((
         Mesh3d(mesh.clone()),
         standard_materials.pz,
-        Transform::from_translation(Vec3::new(0.0, 0.0, box_size)).with_rotation(rotation_pz),
+        Transform::from_translation(Vec3::new(0.0, 0.0, box_size))
+            .with_rotation(Quat::from_rotation_x(-PI * 0.5) * Quat::from_rotation_y(PI)),
         SkyboxPlane {
             orig_translation: Vec3::new(0.0, 0.0, box_size),
-            orig_rotation: rotation_pz,
         },
     ));
 }
@@ -128,7 +121,7 @@ pub(crate) fn setup_daylight(mut commands: Commands) {
 
 pub(crate) fn update_skybox_transform(
     camera: Single<
-        (&GlobalTransform, &Camera, &Projection),
+        (&Transform, &Camera, &Projection),
         (Without<SkyboxPlane>, With<CloudCamera>),
     >,
     mut skybox: Query<(&mut Transform, &SkyboxPlane)>,
@@ -143,7 +136,6 @@ pub(crate) fn update_skybox_transform(
 
     for (mut transform, plane) in skybox.iter_mut() {
         transform.scale = Vec3::splat(scale);
-        transform.translation = camera.0.translation() + plane.orig_translation * scale;
-        transform.rotation = plane.orig_rotation;
+        transform.translation = camera.0.translation + plane.orig_translation * scale;
     }
 }


### PR DESCRIPTION
This pull requests adds a tag component that can be applied to a camera to specify that it should have clouds. Previously, this plugin will not work for any project with multiple cameras. I changed the compute shader pipeline to not assume that there is only one camera. I did not make it fully support rendering clouds to multiple cameras but a lot of the support for that feature is included in this PR. I updated the examples and the readme with information about the CloudCamera component. 